### PR TITLE
Add ability to configure which configuration-service to use

### DIFF
--- a/cmd/keptn-generic-job-service/main.go
+++ b/cmd/keptn-generic-job-service/main.go
@@ -76,7 +76,10 @@ func processKeptnCloudEvent(ctx context.Context, event cloudevents.Event) error 
 		log.Printf("failed to convert incoming cloudevent: %v", err)
 	}
 
-	return eventhandler.HandleEvent(myKeptn, event, eventDataAsInterface, eventData, ServiceName)
+	// prevent duplicate events - https://github.com/keptn/keptn/issues/3888
+	go eventhandler.HandleEvent(myKeptn, event, eventDataAsInterface, eventData, ServiceName)
+
+	return nil
 }
 
 /**

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -11,15 +11,25 @@ type Config struct {
 }
 
 type Action struct {
-	Name     string   `yaml:"name"`
-	Event    string   `yaml:"event"`
-	JsonPath JsonPath `yaml:"jsonpath"`
-	Tasks    []Task   `yaml:"tasks"`
+	Name          string        `yaml:"name"`
+	Event         string        `yaml:"event"`
+	JsonPath      JsonPath      `yaml:"jsonpath"`
+	Configuration Configuration `yaml:"configuration"`
+	Tasks         []Task        `yaml:"tasks"`
 }
 
 type JsonPath struct {
 	Property string `yaml:"property"`
 	Match    string `yaml:"match"`
+}
+
+type Configuration struct {
+	ConfigurationService ConfigurationService `yaml:"configurationService"`
+}
+
+type ConfigurationService struct {
+	Url                   string `yaml:"url"`
+	CredentialsSecretName string `yaml:"credentialsSecretName"`
 }
 
 type Task struct {

--- a/pkg/file/file.go
+++ b/pkg/file/file.go
@@ -4,14 +4,16 @@ import (
 	"didiladi/keptn-generic-job-service/pkg/config"
 	"didiladi/keptn-generic-job-service/pkg/keptn"
 	"fmt"
-	"github.com/spf13/afero"
 	"log"
 	"path/filepath"
+
+	"github.com/spf13/afero"
 )
 
 func MountFiles(actionName string, taskName string, fs afero.Fs, configService keptn.KeptnConfigService) error {
 
-	resource, err := configService.GetKeptnResource("generic-job/config.yaml")
+	// https://github.com/keptn/keptn/issues/2707
+	resource, err := configService.GetKeptnResource("generic-job%2Fconfig.yaml")
 	if err != nil {
 		log.Printf("Could not find config for generic Job service")
 		return err


### PR DESCRIPTION
Adds a `configuration` section to an action, that currently only allows adjusting the `configurationService` for use in a remote execution plane.

Example `config.yaml`:

```yaml
actions:
  - name: "Run locust"
    event: "sh.keptn.event.test.triggered"
    jsonpath:
      property: "$.data.test.teststrategy" 
      match: "locust"
    configuration:
      configurationService:
        apiEndpoint: https://keptn.example.com/api/configuration-service
        credentialsSecretName: keptn-creds
    tasks:
      - name: "Run locust smoke tests"
        files: 
          - locust/basic.py
          - locust/import.py
        image: "locustio/locust"
        cmd: "locust -f /keptn/locust/basic.py"
```

A Keptn API token is expected to be mounted from a Secret with a name indicated by `credentialsSecretName`.

This PR is raised without additional tests/examples to get some early feedback on the approach. Feedback appreciated.

Resolves #4 