### PR TITLE
Add additional properties of the event accessible for matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ actions:
     events:
     - name: "sh.keptn.event.test.triggered"
       jsonpath:
-        property: "$.test.teststrategy" 
+        property: "$.data.test.teststrategy" 
         match: "health"
     - name: "sh.keptn.event.test.triggered"
       jsonpath:
-        property: "$.test.teststrategy"
+        property: "$.data.test.teststrategy"
         match: "load"
     tasks:
       - name: "Run locust smoke tests"
@@ -50,16 +50,16 @@ actions:
 
 The configuration located in `<service>/job/config.yaml` contains the following section for each event:
 
-```
+```yaml
     jsonpath:
-      property: "$.test.teststrategy" 
+      property: "$.data.test.teststrategy" 
       match: "locust"
 ```
 
 If the service receives an event which matches the jsonpath match expression, the specified tasks are executed. E.g. the 
 following cloud event would match the jsonpath above:
 
-```
+```json
 {
     "type": "sh.keptn.event.test.triggered",
     "specversion": "1.0",
@@ -80,7 +80,7 @@ following cloud event would match the jsonpath above:
       "status": "succeeded",
       "result": "pass",
       "test": {
-        teststrategy": "locust"
+        "teststrategy": "locust"
       }
     }
   }
@@ -90,7 +90,7 @@ following cloud event would match the jsonpath above:
 
 The configuration contains the following section:
 
-```
+```yaml
     tasks:
       - name: "Run locust smoke tests"
         files: 
@@ -109,7 +109,7 @@ finished cloud event.
 
 Files can be added to your running tasks by specifying them in the `files` section of your tasks:
 
-```
+```yaml
         files: 
           - locust/basic.py
           - locust/import.py
@@ -121,7 +121,7 @@ and the location will be preserved.
 
 When using these files in your comtainer command, please make sure to reference them by prepending the `keptn` path. E.g.:
 
-```
+```yaml
         cmd: "locust -f /keptn/locust/locustfile.py"
 ```
 

--- a/pkg/eventhandler/eventhandler_test.go
+++ b/pkg/eventhandler/eventhandler_test.go
@@ -3,13 +3,38 @@ package eventhandler
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/cloudevents/sdk-go/v2/binding/spec"
+	"github.com/cloudevents/sdk-go/v2/event"
 	"github.com/keptn/go-utils/pkg/lib/keptn"
 	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
 	"github.com/keptn/go-utils/pkg/lib/v0_2_0/fake"
+	"gotest.tools/assert"
 	"io/ioutil"
+	"testing"
+	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2" // make sure to use v2 cloudevents here
 )
+
+const testEvent = `
+{
+      "project": "sockshop",
+      "stage": "dev",
+      "service": "carts",
+      "labels": {
+        "testId": "4711",
+        "buildId": "build-17",
+        "owner": "JohnDoe"
+      },
+      "status": "succeeded",
+      "result": "pass",
+      "action": {
+        "name": "run locust tests",
+        "action": "hello",
+        "description": "so something as defined in remediation.yaml",
+        "value" : "1"
+      }
+}`
 
 /**
  * loads a cloud event from the passed test json file and initializes a keptn object with it
@@ -35,4 +60,34 @@ func initializeTestObjects(eventFileName string) (*keptnv2.Keptn, *cloudevents.E
 	myKeptn, err := keptnv2.NewKeptn(incomingEvent, keptnOptions)
 
 	return myKeptn, incomingEvent, err
+}
+
+func TestInitializeEventPayloadAsInterface(t *testing.T) {
+
+	context := spec.V1.NewContext()
+	context.SetID("0123")
+	context.SetSource("sourcysource")
+	now := time.Now()
+	context.SetTime(now)
+	context.SetExtension("shkeptncontext", interface{}("mycontext"))
+
+	eh := EventHandler{
+		Event: event.Event{
+			Context: context,
+			DataEncoded: []byte(testEvent),
+		},
+	}
+
+	eventPayloadAsInterface, err := eh.createEventPayloadAsInterface()
+	assert.NilError(t, err)
+
+	assert.Equal(t, eventPayloadAsInterface["id"], "0123")
+	assert.Equal(t, eventPayloadAsInterface["source"], "sourcysource")
+	assert.Equal(t, eventPayloadAsInterface["time"], now)
+	assert.Equal(t, eventPayloadAsInterface["shkeptncontext"], "mycontext")
+
+	data := eventPayloadAsInterface["data"]
+	dataAsMap := data.(map[string]interface{})
+
+	assert.Equal(t, dataAsMap["project"], "sockshop")
 }


### PR DESCRIPTION
This commit extends the functionality of the eventmatching to also
include these events of the original cloud event:
  * id,
  * source,
  * time,
  * shkeptncontext