### PR TITLE
Match action event names as regex expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,15 +48,21 @@ actions:
 
 ### Event Matching
 
-The configuration located in `<service>/job/config.yaml` contains the following section for each event:
+The tasks of an action are executed if the event name matches. Wildcards can also be used, e.g.
+```yaml
+    - name: "sh.keptn.event.*.triggered"
+```
+Would match events `sh.keptn.event.test.triggered`, `sh.keptn.event.deployment.triggered` and so on.
+
+Optionally the following section can be added to an event:
 
 ```yaml
-    jsonpath:
-      property: "$.data.test.teststrategy" 
-      match: "locust"
+      jsonpath:
+        property: "$.data.test.teststrategy"
+        match: "locust"
 ```
 
-If the service receives an event which matches the jsonpath match expression, the specified tasks are executed. E.g. the 
+If the service receives an event which matches the name and the jsonpath match expression, the specified tasks are executed. E.g. the
 following cloud event would match the jsonpath above:
 
 ```json

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"gopkg.in/yaml.v2"
+	"regexp"
 
 	"github.com/PaesslerAG/jsonpath"
 )
@@ -52,8 +53,9 @@ func (c *Config) IsEventMatch(eventType string, jsonEventData interface{}) (bool
 
 	for _, action := range c.Actions {
 		for _, event := range action.Events {
-			// does the event type match?
-			if event.Name == eventType {
+			// does the event type match with regex?
+			matched, _ := regexp.MatchString(event.Name, eventType)
+			if matched {
 
 				// no JSONPath specified, just match event type
 				if event.JSONPath.Property == "" {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -51,6 +51,7 @@ actions:
           property: "$.action.action"
           match: "goodbye"
       - name: "sh.keptn.event.action.started"
+      - name: "sh.keptn.event.*.triggered"
     tasks:
       - name: "Run static world"
         image: "bash"
@@ -203,13 +204,17 @@ func TestComplexMatch(t *testing.T) {
 
 	// sh.keptn.event.action.started - action: _
 
-	actionTriggeredEvent = getActionEvent("started", "")
-	jsonEventData = interface{}(nil)
-	err = json.Unmarshal([]byte(actionTriggeredEvent), &jsonEventData)
-	assert.NilError(t, err)
-
-	data = jsonEventData.(map[string]interface{})["data"]
-	found, action = config.IsEventMatch("sh.keptn.event.action.started", data)
+	found, action = config.IsEventMatch("sh.keptn.event.action.started", nil)
 	assert.Equal(t, found, true)
 	assert.Equal(t, action.Events[2].Name, "sh.keptn.event.action.started")
+
+	// sh.keptn.event.*.triggered - action: _
+
+	found, action = config.IsEventMatch("sh.keptn.event.action.triggered", nil)
+	assert.Equal(t, found, true)
+	assert.Equal(t, action.Events[3].Name, "sh.keptn.event.*.triggered")
+
+	found, action = config.IsEventMatch("sh.keptn.event.test.triggered", nil)
+	assert.Equal(t, found, true)
+	assert.Equal(t, action.Events[3].Name, "sh.keptn.event.*.triggered")
 }


### PR DESCRIPTION
Allows definition of events as eg.
```yaml
    name: "sh.keptn.event.*.triggered"
```
that would match events like `sh.keptn.event.test.triggered`, `sh.keptn.event.deployment.triggered` and so on.

The underlying logic handles the name as regex expression, so a lot more would be possible but documenting just the wildcard functionality should be enough.