### PR TITLE
Make the location of the initcontainer image configurable

### DIFF
--- a/cmd/job-executor-service/main.go
+++ b/cmd/job-executor-service/main.go
@@ -32,6 +32,8 @@ type envConfig struct {
 	JobNamespace string `envconfig:"JOB_NAMESPACE" required:"true"`
 	// The token of the keptn API
 	KeptnAPIToken string `envconfig:"KEPTN_API_TOKEN"`
+	// The token of the keptn API
+	InitContainerImage string `envconfig:"INIT_CONTAINER_IMAGE"`
 }
 
 // ServiceName specifies the current services name (e.g., used as source when sending CloudEvents)
@@ -82,6 +84,7 @@ func processKeptnCloudEvent(ctx context.Context, event cloudevents.Event) error 
 		JobNamespace: env.JobNamespace,
 		InitContainerConfigurationServiceAPIEndpoint: env.InitContainerConfigurationServiceAPIEndpoint,
 		KeptnAPIToken: env.KeptnAPIToken,
+		InitContainerImage: env.InitContainerImage,
 	}
 
 	// prevent duplicate events - https://github.com/keptn/keptn/issues/3888

--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -27,6 +27,8 @@ spec:
               value: 'http://configuration-service:8080'
             - name: JOB_NAMESPACE
               value: 'keptn'
+            - name: INIT_CONTAINER_IMAGE
+              value: 'didiladi/job-executor-service-initcontainer'
         - name: distributor
           image: keptn/distributor:0.8.0-alpha
           livenessProbe:

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -4,3 +4,4 @@ metadata:
   name: job-service-config
 data:
   job_namespace: "{{ .Release.Namespace }}"
+  init_container_image: "didiladi/job-executor-service-initcontainer"

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -57,6 +57,11 @@ spec:
               configMapKeyRef:
                 name: job-service-config
                 key: job_namespace
+          - name: INIT_CONTAINER_IMAGE
+            valueFrom:
+              configMapKeyRef:
+                name: job-service-config
+                key: init_container_image
           livenessProbe:
             httpGet:
               path: /health

--- a/pkg/eventhandler/eventhandlers.go
+++ b/pkg/eventhandler/eventhandlers.go
@@ -26,6 +26,7 @@ type EventHandler struct {
 	JobNamespace                                 string
 	InitContainerConfigurationServiceAPIEndpoint string
 	KeptnAPIToken                                string
+	InitContainerImage							 string
 }
 
 // HandleEvent handles all events in a generic manner
@@ -111,7 +112,7 @@ func (eh *EventHandler) startK8sJob(action *config.Action) {
 			return
 		}
 
-		jobErr := k8s.CreateK8sJob(clientset, eh.JobNamespace, jobName, action, task, eh.EventData, eh.InitContainerConfigurationServiceAPIEndpoint, eh.KeptnAPIToken)
+		jobErr := k8s.CreateK8sJob(clientset, eh.JobNamespace, jobName, action, task, eh.EventData, eh.InitContainerConfigurationServiceAPIEndpoint, eh.KeptnAPIToken, eh.InitContainerImage)
 		defer func() {
 			err = k8s.DeleteK8sJob(clientset, eh.JobNamespace, jobName)
 			if err != nil {

--- a/pkg/k8s/job.go
+++ b/pkg/k8s/job.go
@@ -17,7 +17,7 @@ import (
 )
 
 // CreateK8sJob creates a k8s job with the job-executor-service-initcontainer and the job image of the task and waits until the job finishes
-func CreateK8sJob(clientset *kubernetes.Clientset, namespace string, jobName string, action *config.Action, task config.Task, eventData *keptnv2.EventData, configurationServiceURL string, configurationServiceToken string) error {
+func CreateK8sJob(clientset *kubernetes.Clientset, namespace string, jobName string, action *config.Action, task config.Task, eventData *keptnv2.EventData, configurationServiceURL string, configurationServiceToken string, initContainerImage string) error {
 
 	var backOffLimit int32 = 0
 
@@ -59,7 +59,7 @@ func CreateK8sJob(clientset *kubernetes.Clientset, namespace string, jobName str
 					InitContainers: []v1.Container{
 						{
 							Name:            "init-" + jobName,
-							Image:           "yeahservice/job-executor-service-initcontainer",
+							Image:           initContainerImage,
 							ImagePullPolicy: v1.PullAlways,
 							VolumeMounts: []v1.VolumeMount{
 								{


### PR DESCRIPTION
This commit introduces the option to configure the location of the
initcontainer image in the helm chart (via the configmap), or the
deploy.yaml for skaffold. The k8s job will use the specified
imagecontainer. This gives the user the option to introduce
additional functionality before the k8s job run.