### PR TITLE
Also build initcontainer.Dockerfile in ci workflow

### DIFF
--- a/.ci_env
+++ b/.ci_env
@@ -1,2 +1,5 @@
 DOCKER_ORGANIZATION="didiladi"
 IMAGE="job-executor-service"
+IMAGE_INITCONTAINER="job-executor-service-initcontainer"
+DOCKERFILE_SERVICE="Dockerfile"
+DOCKERFILE_INITCONTAINER="initcontainer.Dockerfile"

--- a/.ci_env
+++ b/.ci_env
@@ -1,5 +1,4 @@
 DOCKER_ORGANIZATION="didiladi"
 IMAGE="job-executor-service"
 IMAGE_INITCONTAINER="job-executor-service-initcontainer"
-DOCKERFILE_SERVICE="Dockerfile"
 DOCKERFILE_INITCONTAINER="initcontainer.Dockerfile"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -153,13 +153,23 @@ jobs:
           username: ${{ secrets.REGISTRY_USER }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
-      - id: docker_build
-        name: Docker Build
-        uses: keptn/gh-action-build-docker-image@master
+      - id: docker_build_service
+        name: Docker Build Service
+        uses: yeahservice/gh-action-build-docker-image@feature/add-dockerfile-name-support
         with:
           VERSION: ${{ env.VERSION }}
           IMAGE_NAME: "${{ env.DOCKER_ORGANIZATION }}/${{ env.IMAGE }}"
           DATETIME: ${{ env.DATETIME }}
+          FILE: ${{ env.DOCKERFILE_SERVICE }}
+
+      - id: docker_build_initcontainer
+        name: Docker Build InitContainer
+        uses: yeahservice/gh-action-build-docker-image@feature/add-dockerfile-name-support
+        with:
+          VERSION: ${{ env.VERSION }}
+          IMAGE_NAME: "${{ env.DOCKER_ORGANIZATION }}/${{ env.IMAGE_INITCONTAINER }}"
+          DATETIME: ${{ env.DATETIME }}
+          FILE: ${{ env.DOCKERFILE_INITCONTAINER }}
 
       - id: create_docker_build_report
         name: Create Docker Build Report

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -155,7 +155,7 @@ jobs:
 
       - id: docker_build_service
         name: Docker Build Service
-        uses: yeahservice/gh-action-build-docker-image@master
+        uses: yeahservice/gh-action-build-docker-image@feature/add-dockerfile-name-support
         with:
           VERSION: ${{ env.VERSION }}
           IMAGE_NAME: "${{ env.DOCKER_ORGANIZATION }}/${{ env.IMAGE }}"
@@ -163,7 +163,7 @@ jobs:
 
       - id: docker_build_initcontainer
         name: Docker Build InitContainer
-        uses: yeahservice/gh-action-build-docker-image@master
+        uses: yeahservice/gh-action-build-docker-image@feature/add-dockerfile-name-support
         with:
           VERSION: ${{ env.VERSION }}
           IMAGE_NAME: "${{ env.DOCKER_ORGANIZATION }}/${{ env.IMAGE_INITCONTAINER }}"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -155,7 +155,7 @@ jobs:
 
       - id: docker_build_service
         name: Docker Build Service
-        uses: yeahservice/gh-action-build-docker-image@feature/add-dockerfile-name-support
+        uses: yeahservice/gh-action-build-docker-image@master
         with:
           VERSION: ${{ env.VERSION }}
           IMAGE_NAME: "${{ env.DOCKER_ORGANIZATION }}/${{ env.IMAGE }}"
@@ -163,7 +163,7 @@ jobs:
 
       - id: docker_build_initcontainer
         name: Docker Build InitContainer
-        uses: yeahservice/gh-action-build-docker-image@feature/add-dockerfile-name-support
+        uses: yeahservice/gh-action-build-docker-image@master
         with:
           VERSION: ${{ env.VERSION }}
           IMAGE_NAME: "${{ env.DOCKER_ORGANIZATION }}/${{ env.IMAGE_INITCONTAINER }}"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -160,7 +160,6 @@ jobs:
           VERSION: ${{ env.VERSION }}
           IMAGE_NAME: "${{ env.DOCKER_ORGANIZATION }}/${{ env.IMAGE }}"
           DATETIME: ${{ env.DATETIME }}
-          FILE: ${{ env.DOCKERFILE_SERVICE }}
 
       - id: docker_build_initcontainer
         name: Docker Build InitContainer


### PR DESCRIPTION
The official docker action (https://github.com/docker/build-push-action) does not support getting the build process output in any way and to keep the PR workflow the same as for every other keptn service we would need to post all built images into the PR. So instead I opted for the next easiest solution to extend the existing keptn action in a fork => https://github.com/yeahservice/gh-action-build-docker-image.

Now we can just overwrite the default Dockerfile name in the `with` block
```yaml
        with:
          VERSION: ${{ env.VERSION }}
          IMAGE_NAME: "${{ env.DOCKER_ORGANIZATION }}/${{ env.IMAGE_INITCONTAINER }}"
          DATETIME: ${{ env.DATETIME }}
          FILE: ${{ env.DOCKERFILE_INITCONTAINER }}
```

If this fits our needs, I will try to reintegrate the changes into the keptn upstream