### PR TITLE
Add possibility to provide data from incoming cloud events as environment variables in the job

### DIFF
--- a/cmd/job-executor-service/main.go
+++ b/cmd/job-executor-service/main.go
@@ -83,7 +83,7 @@ func processKeptnCloudEvent(ctx context.Context, event cloudevents.Event) error 
 		ServiceName:  ServiceName,
 		JobNamespace: env.JobNamespace,
 		InitContainerConfigurationServiceAPIEndpoint: env.InitContainerConfigurationServiceAPIEndpoint,
-		KeptnAPIToken: env.KeptnAPIToken,
+		KeptnAPIToken:      env.KeptnAPIToken,
 		InitContainerImage: env.InitContainerImage,
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -37,6 +37,13 @@ type Task struct {
 	Files []string `yaml:"files"`
 	Image string   `yaml:"image"`
 	Cmd   string   `yaml:"cmd"`
+	Env   []Env    `yaml:"env"`
+}
+
+// Env value from the event which will be added as env to the job
+type Env struct {
+	Name  string `yaml:"name"`
+	Value string `yaml:"value"`
 }
 
 // NewConfig creates a new configuration from the provided config file content

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -38,7 +38,10 @@ actions:
           - locust/basic.py
           - locust/import.py
         image: "locustio/locust"
-        cmd: "locust -f /keptn/locust/locustfile.py"
+        cmd: "locust -f /keptn/locust/locustfile.py --host=$HOST"
+        env:
+          - name: HOST
+            value: "$.data.deployment.deploymentURIsLocal[0]"
 
   - name: "Run bash"
     events:

--- a/pkg/eventhandler/eventhandler_test.go
+++ b/pkg/eventhandler/eventhandler_test.go
@@ -73,7 +73,7 @@ func TestInitializeEventPayloadAsInterface(t *testing.T) {
 
 	eh := EventHandler{
 		Event: event.Event{
-			Context: context,
+			Context:     context,
 			DataEncoded: []byte(testEvent),
 		},
 	}

--- a/pkg/eventhandler/eventhandlers.go
+++ b/pkg/eventhandler/eventhandlers.go
@@ -26,7 +26,7 @@ type EventHandler struct {
 	JobNamespace                                 string
 	InitContainerConfigurationServiceAPIEndpoint string
 	KeptnAPIToken                                string
-	InitContainerImage							 string
+	InitContainerImage                           string
 }
 
 // HandleEvent handles all events in a generic manner
@@ -62,7 +62,7 @@ func (eh *EventHandler) HandleEvent() error {
 
 	log.Printf("Match found for event %s of type %s. Starting k8s job to run action '%s'", eh.Event.Context.GetID(), eh.Event.Type(), action.Name)
 
-	eh.startK8sJob(action)
+	eh.startK8sJob(action, eventAsInterface)
 
 	return nil
 }
@@ -89,7 +89,7 @@ func (eh *EventHandler) createEventPayloadAsInterface() (map[string]interface{},
 	return eventAsInterface, nil
 }
 
-func (eh *EventHandler) startK8sJob(action *config.Action) {
+func (eh *EventHandler) startK8sJob(action *config.Action, jsonEventData interface{}) {
 
 	event, err := eh.Keptn.SendTaskStartedEvent(eh.EventData, eh.ServiceName)
 	if err != nil {
@@ -112,7 +112,7 @@ func (eh *EventHandler) startK8sJob(action *config.Action) {
 			return
 		}
 
-		jobErr := k8s.CreateK8sJob(clientset, eh.JobNamespace, jobName, action, task, eh.EventData, eh.InitContainerConfigurationServiceAPIEndpoint, eh.KeptnAPIToken, eh.InitContainerImage)
+		jobErr := k8s.CreateK8sJob(clientset, eh.JobNamespace, jobName, action, task, eh.EventData, eh.InitContainerConfigurationServiceAPIEndpoint, eh.KeptnAPIToken, eh.InitContainerImage, jsonEventData)
 		defer func() {
 			err = k8s.DeleteK8sJob(clientset, eh.JobNamespace, jobName)
 			if err != nil {

--- a/pkg/k8s/job.go
+++ b/pkg/k8s/job.go
@@ -191,7 +191,7 @@ func prepareJobEnv(task config.Task, eventData *keptnv2.EventData, jsonEventData
 	for _, env := range task.Env {
 		value, err := jsonpath.Get(env.Value, jsonEventData)
 		if err != nil {
-			return fmt.Errorf("Could not add env with name %v, value %v: %v", env.Name, env.Value, err), nil
+			return fmt.Errorf("could not add env with name %v, value %v: %v", env.Name, env.Value, err), nil
 		}
 
 		jobEnv = append(jobEnv, v1.EnvVar{

--- a/pkg/k8s/job.go
+++ b/pkg/k8s/job.go
@@ -43,7 +43,7 @@ func CreateK8sJob(clientset *kubernetes.Clientset, namespace string, jobName str
 		return &s
 	}
 
-	err, jobEnv := prepareJobEnv(task, eventData, jsonEventData)
+	jobEnv, err := prepareJobEnv(task, eventData, jsonEventData)
 	if err != nil {
 		return fmt.Errorf("could not prepare env for job %v: %v", jobName, err.Error())
 	}
@@ -185,13 +185,13 @@ func DeleteK8sJob(clientset *kubernetes.Clientset, namespace string, jobName str
 	return jobs.Delete(context.TODO(), jobName, metav1.DeleteOptions{})
 }
 
-func prepareJobEnv(task config.Task, eventData *keptnv2.EventData, jsonEventData interface{}) (error, []v1.EnvVar) {
+func prepareJobEnv(task config.Task, eventData *keptnv2.EventData, jsonEventData interface{}) ([]v1.EnvVar, error) {
 
 	var jobEnv []v1.EnvVar
 	for _, env := range task.Env {
 		value, err := jsonpath.Get(env.Value, jsonEventData)
 		if err != nil {
-			return fmt.Errorf("could not add env with name %v, value %v: %v", env.Name, env.Value, err), nil
+			return nil, fmt.Errorf("could not add env with name %v, value %v: %v", env.Name, env.Value, err)
 		}
 
 		jobEnv = append(jobEnv, v1.EnvVar{
@@ -215,5 +215,5 @@ func prepareJobEnv(task config.Task, eventData *keptnv2.EventData, jsonEventData
 		},
 	)
 
-	return nil, jobEnv
+	return jobEnv, nil
 }

--- a/pkg/k8s/job_test.go
+++ b/pkg/k8s/job_test.go
@@ -69,7 +69,7 @@ func TestPrepareJobEnv(t *testing.T) {
 	var eventAsInterface interface{}
 	json.Unmarshal([]byte(testTriggeredEvent), &eventAsInterface)
 
-	err, jobEnv := prepareJobEnv(task, &eventData, eventAsInterface)
+	jobEnv, err := prepareJobEnv(task, &eventData, eventAsInterface)
 	assert.NilError(t, err)
 
 	assert.Equal(t, jobEnv[0].Name, "HOST")
@@ -110,6 +110,6 @@ func TestPrepareJobEnvWithWrongJSONPath(t *testing.T) {
 	var eventAsInterface interface{}
 	json.Unmarshal([]byte(testTriggeredEvent), &eventAsInterface)
 
-	err, _ := prepareJobEnv(task, &eventData, eventAsInterface)
+	_, err := prepareJobEnv(task, &eventData, eventAsInterface)
 	assert.ErrorContains(t, err, "unknown key undeploymentstrategy")
 }

--- a/pkg/k8s/job_test.go
+++ b/pkg/k8s/job_test.go
@@ -69,7 +69,8 @@ func TestPrepareJobEnv(t *testing.T) {
 	var eventAsInterface interface{}
 	json.Unmarshal([]byte(testTriggeredEvent), &eventAsInterface)
 
-	jobEnv := prepareJobEnv(task, &eventData, eventAsInterface)
+	err, jobEnv := prepareJobEnv(task, &eventData, eventAsInterface)
+	assert.NilError(t, err)
 
 	assert.Equal(t, jobEnv[0].Name, "HOST")
 	assert.Equal(t, jobEnv[0].Value, "https://keptn.sh")
@@ -88,4 +89,27 @@ func TestPrepareJobEnv(t *testing.T) {
 
 	assert.Equal(t, jobEnv[5].Name, "KEPTN_SERVICE")
 	assert.Equal(t, jobEnv[5].Value, "carts")
+}
+
+func TestPrepareJobEnvWithWrongJSONPath(t *testing.T) {
+	task := config.Task{
+		Env: []config.Env{
+			{
+				Name:  "DEPLOYMENT_STRATEGY",
+				Value: "$.data.deployment.undeploymentstrategy",
+			},
+		},
+	}
+
+	eventData := keptnv2.EventData{
+		Project: "sockshop",
+		Stage:   "dev",
+		Service: "carts",
+	}
+
+	var eventAsInterface interface{}
+	json.Unmarshal([]byte(testTriggeredEvent), &eventAsInterface)
+
+	err, _ := prepareJobEnv(task, &eventData, eventAsInterface)
+	assert.ErrorContains(t, err, "unknown key undeploymentstrategy")
 }

--- a/pkg/k8s/job_test.go
+++ b/pkg/k8s/job_test.go
@@ -1,0 +1,91 @@
+package k8s
+
+import (
+	"didiladi/job-executor-service/pkg/config"
+	"encoding/json"
+	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
+	"gotest.tools/assert"
+	"testing"
+)
+
+const testTriggeredEvent = `
+{
+  "data": {
+    "deployment": {
+      "deploymentNames": [
+        "user_managed"
+      ],
+      "deploymentURIsLocal": [
+        "https://keptn.sh",
+        "https://keptn2.sh"
+      ],
+      "deploymentURIsPublic": [
+        ""
+      ],
+      "deploymentstrategy": "user_managed",
+      "gitCommit": "eb5fc3d5253b1845d3d399c880c329374bbbb30e"
+    },
+    "message": "",
+    "project": "sockshop",
+    "stage": "dev",
+    "service": "carts",
+    "status": "succeeded",
+    "test": {
+      "teststrategy": "health"
+    }
+  },
+  "id": "4fe1eed1-49e2-49a9-91af-a42c8b0f7811",
+  "source": "shipyard-controller",
+  "specversion": "1.0",
+  "time": "2021-05-13T07:46:09.546Z",
+  "type": "sh.keptn.event.test.triggered",
+  "shkeptncontext": "138f7bf1-f027-42c4-b705-9033b5f5871e"
+}`
+
+func TestPrepareJobEnv(t *testing.T) {
+	task := config.Task{
+		Env: []config.Env{
+			{
+				Name:  "HOST",
+				Value: "$.data.deployment.deploymentURIsLocal[0]",
+			},
+			{
+				Name:  "DEPLOYMENT_STRATEGY",
+				Value: "$.data.deployment.deploymentstrategy",
+			},
+			{
+				Name:  "TEST_STRATEGY",
+				Value: "$.data.test.teststrategy",
+			},
+		},
+	}
+
+	eventData := keptnv2.EventData{
+		Project: "sockshop",
+		Stage:   "dev",
+		Service: "carts",
+	}
+
+	var eventAsInterface interface{}
+	json.Unmarshal([]byte(testTriggeredEvent), &eventAsInterface)
+
+	jobEnv := prepareJobEnv(task, &eventData, eventAsInterface)
+
+	assert.Equal(t, jobEnv[0].Name, "HOST")
+	assert.Equal(t, jobEnv[0].Value, "https://keptn.sh")
+
+	assert.Equal(t, jobEnv[1].Name, "DEPLOYMENT_STRATEGY")
+	assert.Equal(t, jobEnv[1].Value, "user_managed")
+
+	assert.Equal(t, jobEnv[2].Name, "TEST_STRATEGY")
+	assert.Equal(t, jobEnv[2].Value, "health")
+
+	assert.Equal(t, jobEnv[3].Name, "KEPTN_PROJECT")
+	assert.Equal(t, jobEnv[3].Value, "sockshop")
+
+	assert.Equal(t, jobEnv[4].Name, "KEPTN_STAGE")
+	assert.Equal(t, jobEnv[4].Value, "dev")
+
+	assert.Equal(t, jobEnv[5].Name, "KEPTN_SERVICE")
+	assert.Equal(t, jobEnv[5].Value, "carts")
+}


### PR DESCRIPTION
Data from the incoming cloud event can be made available as environment variables in the job. In the `env` section of a
task a list of environment variables can be declared, each with a `name` and a json path for the `value`.

```yaml
        cmd: "locust -f /keptn/locust/basic.py --host=$HOST"
        env:
          - name: HOST
            value: "$.data.deployment.deploymentURIsLocal[0]"
```

In the above example the json path for `HOST` would resolve into `https://keptn.sh` for the below event

```yaml
{
  "data": {
    "deployment": {
      "deploymentNames": [
          "user_managed"
      ],
      "deploymentURIsLocal": [
          "https://keptn.sh"
      ],
      ...
}
```
If a value will be resolved with an error, it gets skipped. Maybe ending the job in an error might be preferable, so that the Keptn Bridge shows feedback on what is wrong?