### PR TITLE
Use golang version 1.16.2

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.16.4
+          go-version: ^1.16.2
       - name: Checkout Code
         uses: actions/checkout@v2
 

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.4
+          go-version: 1.16.2
         id: go
       - name: Check out code.
         uses: actions/checkout@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Use the offical Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.16.4-alpine as builder
+FROM golang:1.16.2-alpine as builder
 
 RUN apk add --no-cache gcc libc-dev git
 

--- a/initcontainer.Dockerfile
+++ b/initcontainer.Dockerfile
@@ -1,7 +1,7 @@
 # Use the offical Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.16.4-alpine as builder
+FROM golang:1.16.2-alpine as builder
 
 RUN apk add --no-cache gcc libc-dev git
 


### PR DESCRIPTION
According to this page https://www.dynatrace.com/support/help/technology-support/application-software/go/#version-matrix one-agent currently supports golang up to 1.16.2. To safe us some later headaches downgrade it now.